### PR TITLE
modifierspack-2900756: Put the speed value in correct array.

### DIFF
--- a/modules/modifiers_bg_parallax/src/Plugin/modifiers/ParallaxBgModifier.php
+++ b/modules/modifiers_bg_parallax/src/Plugin/modifiers/ParallaxBgModifier.php
@@ -40,7 +40,7 @@ class ParallaxBgModifier extends ModifierPluginBase {
         ],
       ];
       if (!empty($config['parallax_speed'])) {
-        $settings['args']['speed'] = $config['parallax_speed'];
+        $settings['args']['parallax']['speed'] = $config['parallax_speed'];
       }
       $attributes['class'][] = 'modifiers-has-background';
 


### PR DESCRIPTION
Hi Dalibor,
here is a patch for correctly using the speed value for Parallax Background modifier.