### PR TITLE
Run modifiers_scroll_reveal apply script only once.

### DIFF
--- a/modules/modifiers_scroll_reveal/js/modifiers_scroll_reveal.apply.js
+++ b/modules/modifiers_scroll_reveal/js/modifiers_scroll_reveal.apply.js
@@ -10,9 +10,11 @@
   ScrollRevealModifier.apply = function (context, selector, media, config) {
 
     var element = context.querySelector(selector);
-    if (!element) {
+    if (!element || window.scroll_was_run) {
       return;
     }
+
+    window.scroll_was_run = true;
 
     var pluginConfig = {
       origin: (typeof config.origin !== 'undefined' ? config.origin : 'bottom'),


### PR DESCRIPTION
This PR solves the following problem:

The issue is that JS code is initialized multiple times (in this case scroll reveal). This is the standard way of implementing JS but when initialized multiple times it is resulting in a broken design (almost all elements that should have been revealed are hidden and you have no way to display them resulting in a broken design).